### PR TITLE
Fixed bug where ltrim deleted unrelated values

### DIFF
--- a/lib/redis_impersonator.rb
+++ b/lib/redis_impersonator.rb
@@ -117,7 +117,7 @@ class RedisImpersonator
   def ltrim(list_name, start_range, end_range)
     limit = end_range - start_range + 1
     ids = ResqueValue.all(:select => "id", :conditions => {:key => list_name}, :offset => start_range, :limit => limit)
-    ResqueValue.delete_all(["id NOT IN (?)", ids.collect{|i| i.id}])
+    ResqueValue.delete_all(["key = ? AND id NOT IN (?)", list_name, ids.collect{|i| i.id}])
   end
   
   def keys(pattern = '*')

--- a/lib/redis_impersonator.rb
+++ b/lib/redis_impersonator.rb
@@ -87,7 +87,10 @@ class RedisImpersonator
     options = { :conditions => {
                   :key => list_name.to_s,
                   :key_type=> LIST}}
-    options.merge!(:limit => end_range, :offset => start_range) unless end_range < 0
+    unless end_range < 0
+      limit = end_range - start_range + 1
+      options.merge!(:limit => limit, :offset => start_range)
+    end
     values = ResqueValue.all(options)
     values.map(&:value)
   end
@@ -109,6 +112,12 @@ class RedisImpersonator
   
   def rpush(list_name, value)
     ResqueValue.create!(:key => list_name.to_s, :key_type => LIST, :value => value.to_s)
+  end
+  
+  def ltrim(list_name, start_range, end_range)
+    limit = end_range - start_range + 1
+    ids = ResqueValue.all(:select => "id", :conditions => {:key => list_name}, :offset => start_range, :limit => limit)
+    ResqueValue.delete_all(["id NOT IN (?)", ids.collect{|i| i.id}])
   end
   
   def keys(pattern = '*')

--- a/lib/redis_impersonator.rb
+++ b/lib/redis_impersonator.rb
@@ -117,7 +117,7 @@ class RedisImpersonator
   def ltrim(list_name, start_range, end_range)
     limit = end_range - start_range + 1
     ids = ResqueValue.all(:select => "id", :conditions => {:key => list_name}, :offset => start_range, :limit => limit)
-    ResqueValue.delete_all(["key = ? AND id NOT IN (?)", list_name, ids.collect{|i| i.id}])
+    ResqueValue.delete_all(["`key` = ? AND id NOT IN (?)", list_name, ids.collect{|i| i.id}])
   end
   
   def keys(pattern = '*')

--- a/spec/redis_impersonator_spec.rb
+++ b/spec/redis_impersonator_spec.rb
@@ -134,6 +134,19 @@ describe 'RedisImpersonator' do
       impersonator.lrange('some_queue', 0, -1).should include('one')
     end
     
+    it "should trim according to the specifed start and end" do
+      1.upto(6){|i| impersonator.rpush('some_queue', i)}
+      impersonator.ltrim('some_queue', 1, 3)
+      impersonator.llen('some_queue').should == 3
+      impersonator.lrange('some_queue', 0, 2).should == ["2","3","4"]
+    end
+    
+    it "should get a range of values" do
+      1.upto(6){|i| impersonator.rpush('some_queue', i)}
+      impersonator.lrange('some_queue', 0, 5).should == ['1','2','3','4','5','6']
+      impersonator.lrange('some_queue', 1, 3).should == ['2','3','4']
+    end
+    
   end
   
   it 'should increment a value' do

--- a/spec/redis_impersonator_spec.rb
+++ b/spec/redis_impersonator_spec.rb
@@ -141,6 +141,13 @@ describe 'RedisImpersonator' do
       impersonator.lrange('some_queue', 0, 2).should == ["2","3","4"]
     end
     
+    it "should not affect other keys when trimming" do
+      1.upto(3){|i| impersonator.rpush('some_queue', i)}
+      impersonator.set('something_else', 'independent value')
+      impersonator.ltrim('some_queue', 0, 0)
+      impersonator.get('something_else').should == 'independent value'
+    end
+    
     it "should get a range of values" do
       1.upto(6){|i| impersonator.rpush('some_queue', i)}
       impersonator.lrange('some_queue', 0, 5).should == ['1','2','3','4','5','6']


### PR DESCRIPTION
If I had two keys, "list" and "random key", doing an ltrim on list would delete "random key" and every other key. This has been fixed
